### PR TITLE
Add onExit callback, export Modal, bump react v17 peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "files": [
     "dist"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,1 +1,2 @@
 export {MetrcLink} from './stories/components/metrc-link/MetrcLink'
+export {Modal} from './stories/components/modal/Modal'

--- a/src/stories/components/metrc-link/MetrcLink.tsx
+++ b/src/stories/components/metrc-link/MetrcLink.tsx
@@ -84,6 +84,10 @@ export interface MetrcLinkProps {
      * Company name to use on privacy screen
      */
     privacyPolicyLink:string;
+    /**
+     * Called when modal is closed
+     */
+     onExit?: () => void;
 }
 
 export const MetrcLink: React.FC<MetrcLinkProps>= ({
@@ -103,7 +107,8 @@ export const MetrcLink: React.FC<MetrcLinkProps>= ({
     padding,
     margin,
     companyName,
-    privacyPolicyLink
+    privacyPolicyLink,
+    onExit
   }) => {
     const [open, setOpen]=useState(false)
     const [screen, setScreen]=useState("privacy")
@@ -115,6 +120,7 @@ export const MetrcLink: React.FC<MetrcLinkProps>= ({
     const closeModal =() =>{
         setOpen(false)
         handleSetScreen('privacy')
+        onExit?.()
     }
 
     const handleSetScreen = (screenName:string) =>{


### PR DESCRIPTION
Sorry for the 3 different changes in the same PR. All are small so I didn't want to create 3 separate PRs.

I need Modal exported to use it separately from the button (it is activated programmatically from a completely different component). 

`onExit` is to track down when the user leaves a modal before receiving the user_key.